### PR TITLE
Update statefulset.yaml

### DIFF
--- a/charts/kafka/templates/statefulset.yaml
+++ b/charts/kafka/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       affinity:
       {{- if .Values.affinity }}
-        {{ toYaml .Values.affinity | indent 8 }}
+        {{ toYaml .Values.affinity | nindent 8 }}
       {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/zookeeper/templates/statefulset.yaml
+++ b/charts/zookeeper/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       affinity:
       {{- if .Values.affinity }}
-        {{ toYaml .Values.affinity | indent 8 }}
+        {{ toYaml .Values.affinity | nindent 8 }}
       {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Getting below error when adding values for affinity
 affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions: - key: nodeKind operator: In values: - kube-events podAntiAffinity: preferredDuringSchedulingIgnoredDuringExecution: - weight: 1 podAffinityTerm: labelSelector: matchExpressions: - key: app operator: In values: - kafka topologyKey: kubernetes.io/hostname

YAML parse error on kafka/charts/zookeeper/templates/statefulset.yaml: error converting YAML to JSON: yaml: line 34: did not find expected key
  │ 
  │   with module.eks_cluster_1.module.kafka[0].helm_release.kafka,
  │   on ../../modules/k8s_eks_cluster_set_type1/dependent_modules_symlinks/shared/modules/k8s_kafka/main.tf line 5, in resource "helm_release" "kafka":
  │    5: resource "helm_release" "kafka" {